### PR TITLE
feat: add Formula recipe for building Recoll from source

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,20 +110,20 @@ jobs:
           rm -rf "$tap_dir/homebrew-recoll"
           ln -s "$GITHUB_WORKSPACE" "$tap_dir/homebrew-recoll"
           # Verify the linked Formula matches the PR branch
-          head -5 Formula/recoll.rb
+          head -5 Formula/recoll-from-source.rb
 
       - name: Audit Formula
-        run: brew audit --formula nailuoGG/recoll/recoll --online
+        run: brew audit --formula nailuoGG/recoll/recoll-from-source --online
 
       - name: Build and install
-        run: brew install --formula --build-from-source nailuoGG/recoll/recoll
+        run: brew install --build-from-source nailuoGG/recoll/recoll-from-source
 
       - name: Test installation
-        run: brew test --formula nailuoGG/recoll/recoll
+        run: brew test nailuoGG/recoll/recoll-from-source
 
       - name: Clean up
         if: always()
         run: |
-          brew uninstall --formula --force recoll || true
+          brew uninstall --force recoll-from-source || true
           rm -rf "$HOME/.recoll" || true
           echo "Cleanup completed"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,10 +83,38 @@ jobs:
         run: |
           # Clean up the installation to free up space
           brew uninstall --zap --force recoll || true
-          
+
           # Remove any remaining files
           sudo rm -rf "/Applications/Recoll.app" || true
           rm -rf "$HOME/.recoll" || true
           rm -rf "$HOME/.config/Recoll.org" || true
-          
+
+          echo "Cleanup completed"
+
+  test-formula:
+    name: Test Recoll Formula
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+
+      - name: Audit Formula
+        run: brew audit --formula ./Formula/recoll.rb --online
+
+      - name: Build and install
+        run: brew install --build-from-source --formula ./Formula/recoll.rb
+
+      - name: Test installation
+        run: brew test --formula ./Formula/recoll.rb
+
+      - name: Clean up
+        if: always()
+        run: |
+          brew uninstall --force recoll || true
+          rm -rf "$HOME/.recoll" || true
           echo "Cleanup completed"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -116,14 +116,14 @@ jobs:
         run: brew audit --formula nailuoGG/recoll/recoll --online
 
       - name: Build and install
-        run: brew install --build-from-source nailuoGG/recoll/recoll
+        run: brew install --formula --build-from-source nailuoGG/recoll/recoll
 
       - name: Test installation
-        run: brew test nailuoGG/recoll/recoll
+        run: brew test --formula nailuoGG/recoll/recoll
 
       - name: Clean up
         if: always()
         run: |
-          brew uninstall --force recoll || true
+          brew uninstall --formula --force recoll || true
           rm -rf "$HOME/.recoll" || true
           echo "Cleanup completed"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,12 @@ jobs:
 
       - name: Link tap for testing
         run: |
-          ln -s "$GITHUB_WORKSPACE" "$(brew --repository)/Library/Taps/nailuoGG/homebrew-recoll"
+          tap_dir="$(brew --repository)/Library/Taps/nailuoGG"
+          mkdir -p "$tap_dir"
+          rm -rf "$tap_dir/homebrew-recoll"
+          ln -s "$GITHUB_WORKSPACE" "$tap_dir/homebrew-recoll"
+          # Verify the linked Formula matches the PR branch
+          head -5 Formula/recoll.rb
 
       - name: Audit Formula
         run: brew audit --formula nailuoGG/recoll/recoll --online

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,14 +103,18 @@ jobs:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
+      - name: Link tap for testing
+        run: |
+          ln -s "$GITHUB_WORKSPACE" "$(brew --repository)/Library/Taps/nailuoGG/homebrew-recoll"
+
       - name: Audit Formula
-        run: brew audit --formula ./Formula/recoll.rb --online
+        run: brew audit --formula nailuoGG/recoll/recoll --online
 
       - name: Build and install
-        run: brew install --build-from-source --formula ./Formula/recoll.rb
+        run: brew install --build-from-source nailuoGG/recoll/recoll
 
       - name: Test installation
-        run: brew test --formula ./Formula/recoll.rb
+        run: brew test nailuoGG/recoll/recoll
 
       - name: Clean up
         if: always()

--- a/.github/workflows/update-recoll.yml
+++ b/.github/workflows/update-recoll.yml
@@ -34,8 +34,20 @@ jobs:
             "${{ steps.check_updates.outputs.version }}" \
             "${{ steps.check_updates.outputs.sha256 }}"
 
+      - name: Check Formula version
+        id: check_formula
+        run: |
+          ./scripts/check-formula-version.sh
+
+      - name: Update Formula if needed
+        if: steps.check_formula.outputs.formula_update_needed == 'true'
+        run: |
+          ./scripts/update-formula.sh \
+            "${{ steps.check_formula.outputs.formula_version }}" \
+            "${{ steps.check_formula.outputs.formula_sha256 }}"
+
       - name: Create Pull Request
-        if: steps.check_updates.outputs.update_needed == 'true'
+        if: steps.check_updates.outputs.update_needed == 'true' || steps.check_formula.outputs.formula_update_needed == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -48,8 +60,11 @@ jobs:
       - name: Summary
         run: |
           if [ "${{ steps.check_updates.outputs.update_needed }}" == "true" ]; then
-            echo "✅ Update completed successfully!"
-            echo "Updated Recoll from ${{ steps.check_updates.outputs.current_version }} to ${{ steps.check_updates.outputs.version }}"
-          else
-            echo "ℹ️ No update needed. Recoll is already up to date."
+            echo "Cask updated from ${{ steps.check_updates.outputs.current_version }} to ${{ steps.check_updates.outputs.version }}"
+          fi
+          if [ "${{ steps.check_formula.outputs.formula_update_needed }}" == "true" ]; then
+            echo "Formula updated to ${{ steps.check_formula.outputs.formula_version }}"
+          fi
+          if [ "${{ steps.check_updates.outputs.update_needed }}" != "true" ] && [ "${{ steps.check_formula.outputs.formula_update_needed }}" != "true" ]; then
+            echo "No updates needed. Both Cask and Formula are up to date."
           fi

--- a/Formula/recoll-from-source.rb
+++ b/Formula/recoll-from-source.rb
@@ -1,4 +1,4 @@
-class Recoll < Formula
+class RecollFromSource < Formula
   desc "Full-text search for your desktop"
   homepage "https://www.recoll.org/"
   url "https://www.recoll.org/recoll-1.43.14.tar.gz"

--- a/Formula/recoll.rb
+++ b/Formula/recoll.rb
@@ -1,0 +1,93 @@
+class Recoll < Formula
+  desc "Full-text search for your desktop"
+  homepage "https://www.recoll.org/"
+  url "https://www.recoll.org/recoll-1.43.14.tar.gz"
+  sha256 "391e5c6edb78c6cd487d94c5abe44fe0c64f99f0acdab287d5821fd4e806f89b"
+  license "GPL-2.0-or-later"
+  head "https://framagit.org/medoc92/recoll.git", branch: "master"
+
+  livecheck do
+    url "https://www.recoll.org/pages/download.html"
+    regex(/href=.*?recoll[._-]v?(\d+(?:\.\d+)+)\.t/i)
+  end
+
+  depends_on "meson" => :build
+  depends_on "ninja" => :build
+  depends_on "pkg-config" => :build
+  depends_on "aspell"
+  depends_on "jsoncpp"
+  depends_on "libmagic"
+  depends_on "libxml2"
+  depends_on "libxslt"
+  depends_on "python@3.13"
+  depends_on "qt@6"
+  depends_on "xapian"
+
+  def install
+    # Fix missing IOKit framework for power status on macOS
+    iokit_line = "    librecolldeps += dependency('IOKit', required: true)"
+    inreplace "meson.build",
+              "librecolldeps += core_services  # Add the CoreServices framework as a dependency",
+              "librecolldeps += core_services  # Add the CoreServices framework as a dependency\n#{iokit_line}"
+
+    # Fix rclgrep missing iconv and macOS framework deps
+    iconv_dep = "dependency('iconv', method: 'auto')"
+    inreplace "rclgrep/meson.build",
+              "rclgrep_deps = [libxml, libxslt, libz]",
+              "rclgrep_deps = [libxml, libxslt, libz, #{iconv_dep}]"
+    rclgrep_macos = [
+      "    rclgrep_deps += libmagic",
+      "    if(apple_core_services_found)",
+      "        rclgrep_deps += core_services",
+      "        rclgrep_deps += dependency('IOKit', required: true)",
+      "    endif",
+    ].join("\n")
+    inreplace "rclgrep/meson.build",
+              "    rclgrep_deps += libmagic",
+              rclgrep_macos
+    inreplace "rclgrep/meson.build",
+              "    '../utils/zlibut.cpp',",
+              "    '../utils/zlibut.cpp',\n    '../internfile/finderxattr.cpp',"
+
+    args = %w[
+      -Dpython-module=true
+      -Dqtgui=true
+      -Dfsevents=true
+      -Daspell=true
+      -Drecollq=true
+      -Drclgrep=true
+      -Dwebkit=false
+      -Dwebengine=true
+      -Dwebpreview=true
+      -Didxthreads=false
+      -Dx11mon=false
+      -Dinotify=false
+      -Dsystemd=false
+    ]
+
+    system "meson", "setup", "build", *args, *std_meson_args
+    system "meson", "compile", "-C", "build", "--verbose"
+    system "meson", "install", "-C", "build"
+  end
+
+  def caveats
+    <<~EOS
+      Recoll has been installed from source with Qt6 GUI support.
+
+      To start the GUI:
+        recoll
+
+      To index your home directory:
+        recollindex
+
+      Configuration files are stored in ~/.recoll/
+
+      For more information:
+        https://www.recoll.org/
+    EOS
+  end
+
+  test do
+    system bin/"recollindex", "-h"
+  end
+end

--- a/Formula/recoll.rb
+++ b/Formula/recoll.rb
@@ -24,30 +24,29 @@ class Recoll < Formula
   depends_on "xapian"
 
   def install
-    # Fix missing IOKit framework for power status on macOS
-    iokit_line = "    librecolldeps += dependency('IOKit', required: true)"
+    # Upstream meson.build omits IOKit, needed by powerstatus.cpp on macOS
+    iokit_dep = "    librecolldeps += dependency('IOKit', required: true)"
     inreplace "meson.build",
               "librecolldeps += core_services  # Add the CoreServices framework as a dependency",
-              "librecolldeps += core_services  # Add the CoreServices framework as a dependency\n#{iokit_line}"
+              "librecolldeps += core_services  # Add the CoreServices framework as a dependency\n#{iokit_dep}"
 
-    # Fix rclgrep missing iconv and macOS framework deps
-    iconv_dep = "dependency('iconv', method: 'auto')"
-    inreplace "rclgrep/meson.build",
-              "rclgrep_deps = [libxml, libxslt, libz]",
-              "rclgrep_deps = [libxml, libxslt, libz, #{iconv_dep}]"
-    rclgrep_macos = [
-      "    rclgrep_deps += libmagic",
-      "    if(apple_core_services_found)",
-      "        rclgrep_deps += core_services",
-      "        rclgrep_deps += dependency('IOKit', required: true)",
-      "    endif",
-    ].join("\n")
-    inreplace "rclgrep/meson.build",
-              "    rclgrep_deps += libmagic",
-              rclgrep_macos
-    inreplace "rclgrep/meson.build",
-              "    '../utils/zlibut.cpp',",
+    # Upstream rclgrep/meson.build misses iconv, CoreServices/IOKit, and
+    # finderxattr.cpp (only added to librecoll, not rclgrep's source list)
+    inreplace "rclgrep/meson.build" do |s|
+      s.gsub! "rclgrep_deps = [libxml, libxslt, libz]",
+              "rclgrep_deps = [libxml, libxslt, libz, dependency('iconv', method: 'auto')]"
+      macos_patch = <<~MESON
+        rclgrep_deps += libmagic
+        if(apple_core_services_found)
+            rclgrep_deps += core_services
+            rclgrep_deps += dependency('IOKit', required: true)
+        endif
+      MESON
+      s.gsub! "    rclgrep_deps += libmagic",
+              macos_patch
+      s.gsub! "    '../utils/zlibut.cpp',",
               "    '../utils/zlibut.cpp',\n    '../internfile/finderxattr.cpp',"
+    end
 
     args = %w[
       -Dpython-module=true

--- a/README.org
+++ b/README.org
@@ -21,7 +21,7 @@ Quick install with official macOS binary, no compilation needed.
 
 #+begin_src shell
 brew tap nailuoGG/recoll
-brew install recoll
+brew install recoll-from-source
 #+end_src
 
 Compile from source with Qt6 GUI, Python module, and fsevents support.

--- a/README.org
+++ b/README.org
@@ -2,26 +2,38 @@
 <h1 align="center">Recoll Homebrew Tap</h1>
 #+end_html
 
-** Lazy Homebrew install for Recoll on macOS
+** Homebrew tap for Recoll on macOS
 
-This is just a convenience tap that packages the official Recoll macOS builds 
-as a Homebrew cask. No compilation from source - just the official binaries.
+Two ways to install Recoll: pre-built binary (quick) or build from source (customizable).
 
-** Quick Install
+** Installation
+
+*** Option 1: Pre-built Binary (recommended)
 
 #+begin_src shell
 brew tap nailuoGG/recoll
 brew install --cask recoll
 #+end_src
 
+Quick install with official macOS binary, no compilation needed.
+
+*** Option 2: Build from Source
+
+#+begin_src shell
+brew tap nailuoGG/recoll
+brew install recoll
+#+end_src
+
+Compile from source with Qt6 GUI, Python module, and fsevents support.
+
 That's it. Run ~recoll~ to start searching.
 
 ** Details
 
-- Uses official binaries from [[https://www.recoll.org/downloads/macos/]]
-- No source compilation (QT dependencies are complex)
+- Cask uses official binaries from [[https://www.recoll.org/downloads/macos/]]
+- Formula builds from source via Meson with Qt6 and Python support
 - Packages are not digitally signed (same as official)
-- Automated updates via GitHub Actions
+- Automated updates via GitHub Actions for both Cask and Formula
 
 ** Links
 

--- a/scripts/check-formula-version.sh
+++ b/scripts/check-formula-version.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-set -euo pipefail
 
 source "$(dirname "$0")/utils.sh"
 
 readonly FORMULA_FILE="Formula/recoll.rb"
 readonly FORMULA_DOWNLOAD_PAGE="https://www.recoll.org/pages/download.html"
 readonly SOURCE_URL_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz"
+readonly SOURCE_SHA256_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz.sha256"
 
 fetch_latest_source_version() {
     log_info "Fetching latest source version from download page..."
@@ -14,33 +14,25 @@ fetch_latest_source_version() {
     page_content=$(fetch_webpage "$FORMULA_DOWNLOAD_PAGE")
 
     local latest
-    latest=$(echo "$page_content" | grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+\.tar' | head -1 | sed 's/recoll-\(.*\)\.tar/\1/')
+    latest=$(grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+\.tar' <<< "$page_content" | head -1 | sed 's/recoll-\(.*\)\.tar/\1/')
 
     validate_not_empty "$latest" "Latest source version" || return 1
 
     echo "$latest"
 }
 
-calculate_source_sha256() {
+fetch_source_sha256() {
     local version="$1"
-    local source_url
-    source_url=$(printf "$SOURCE_URL_TEMPLATE" "$version")
+    local sha256_url
+    sha256_url=$(printf "$SOURCE_SHA256_TEMPLATE" "$version")
 
-    log_info "Downloading source tarball to calculate SHA256: $source_url"
+    log_info "Fetching SHA256 from: $sha256_url"
 
-    local temp_file
-    temp_file=$(mktemp)
-
-    if ! curl -sLf -o "$temp_file" "$source_url"; then
-        log_error "Failed to download: $source_url"
-        rm -f "$temp_file"
-        return 1
-    fi
+    local hash_content
+    hash_content=$(fetch_webpage "$sha256_url")
 
     local sha256
-    sha256=$(shasum -a 256 "$temp_file" | cut -d' ' -f1)
-
-    rm -f "$temp_file"
+    sha256=$(echo "$hash_content" | cut -d' ' -f1)
 
     validate_not_empty "$sha256" "Source SHA256" || return 1
     echo "$sha256"
@@ -62,7 +54,7 @@ main() {
         log_success "New version available: $latest_ver"
 
         local sha256
-        sha256=$(calculate_source_sha256 "$latest_ver")
+        sha256=$(fetch_source_sha256 "$latest_ver")
 
         set_github_output "formula_update_needed" "true"
         set_github_output "formula_version" "$latest_ver"

--- a/scripts/check-formula-version.sh
+++ b/scripts/check-formula-version.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils.sh"
 
-readonly FORMULA_FILE="Formula/recoll.rb"
+readonly FORMULA_FILE="Formula/recoll-from-source.rb"
 readonly FORMULA_DOWNLOAD_PAGE="https://www.recoll.org/pages/download.html"
 readonly SOURCE_SHA256_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz.sha256"
 

--- a/scripts/check-formula-version.sh
+++ b/scripts/check-formula-version.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-source "$(dirname "$0")/utils.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
 readonly FORMULA_FILE="Formula/recoll.rb"
 readonly FORMULA_DOWNLOAD_PAGE="https://www.recoll.org/pages/download.html"
-readonly SOURCE_URL_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz"
 readonly SOURCE_SHA256_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz.sha256"
 
 fetch_latest_source_version() {

--- a/scripts/check-formula-version.sh
+++ b/scripts/check-formula-version.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$0")/utils.sh"
+
+readonly FORMULA_FILE="Formula/recoll.rb"
+readonly FORMULA_DOWNLOAD_PAGE="https://www.recoll.org/pages/download.html"
+readonly SOURCE_URL_TEMPLATE="https://www.recoll.org/recoll-%s.tar.gz"
+
+fetch_latest_source_version() {
+    log_info "Fetching latest source version from download page..."
+
+    local page_content
+    page_content=$(fetch_webpage "$FORMULA_DOWNLOAD_PAGE")
+
+    local latest
+    latest=$(echo "$page_content" | grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+\.tar' | head -1 | sed 's/recoll-\(.*\)\.tar/\1/')
+
+    validate_not_empty "$latest" "Latest source version" || return 1
+
+    echo "$latest"
+}
+
+calculate_source_sha256() {
+    local version="$1"
+    local source_url
+    source_url=$(printf "$SOURCE_URL_TEMPLATE" "$version")
+
+    log_info "Downloading source tarball to calculate SHA256: $source_url"
+
+    local temp_file
+    temp_file=$(mktemp)
+
+    if ! curl -sLf -o "$temp_file" "$source_url"; then
+        log_error "Failed to download: $source_url"
+        rm -f "$temp_file"
+        return 1
+    fi
+
+    local sha256
+    sha256=$(shasum -a 256 "$temp_file" | cut -d' ' -f1)
+
+    rm -f "$temp_file"
+
+    validate_not_empty "$sha256" "Source SHA256" || return 1
+    echo "$sha256"
+}
+
+main() {
+    log_info "Checking Formula version..."
+
+    local current_ver
+    current_ver=$(extract_formula_version "$FORMULA_FILE")
+
+    local latest_ver
+    latest_ver=$(fetch_latest_source_version)
+
+    log_info "Current Formula version: $current_ver"
+    log_info "Latest source version: $latest_ver"
+
+    if [[ "$latest_ver" != "$current_ver" ]]; then
+        log_success "New version available: $latest_ver"
+
+        local sha256
+        sha256=$(calculate_source_sha256 "$latest_ver")
+
+        set_github_output "formula_update_needed" "true"
+        set_github_output "formula_version" "$latest_ver"
+        set_github_output "formula_sha256" "$sha256"
+    else
+        log_info "Formula is up to date"
+        set_github_output "formula_update_needed" "false"
+    fi
+}
+
+main "$@"

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-source "$(dirname "$0")/utils.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils.sh"
 
 readonly FORMULA_FILE="Formula/recoll.rb"
 
@@ -16,8 +17,8 @@ update_formula() {
 
     log_info "Updating Formula to version $version..."
 
-    sed -i '' -e "s|url \"https://www.recoll.org/recoll-.*\.tar\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" \
-              -e "s|sha256 \".*\"|sha256 \"${sha256}\"|" "$FORMULA_FILE"
+    perl -pi -e "s|url \"https://www.recoll.org/recoll-.*\\.tar\\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" \
+             -e "s|sha256 \".*\"|sha256 \"${sha256}\"|" "$FORMULA_FILE"
 
     local updated_ver
     updated_ver=$(extract_formula_version "$FORMULA_FILE")

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/utils.sh"
 
-readonly FORMULA_FILE="Formula/recoll.rb"
+readonly FORMULA_FILE="Formula/recoll-from-source.rb"
 
 update_formula() {
     local version="$1"

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$0")/utils.sh"
+
+readonly FORMULA_FILE="Formula/recoll.rb"
+
+update_formula() {
+    local version="$1"
+    local sha256="$2"
+
+    validate_not_empty "$version" "Version" || return 1
+    validate_not_empty "$sha256" "SHA256" || return 1
+    validate_file_exists "$FORMULA_FILE" "Formula file" || return 1
+
+    backup_file "$FORMULA_FILE"
+
+    log_info "Updating Formula to version $version..."
+
+    sed -i.bak "s|url \"https://www.recoll.org/recoll-.*\.tar\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" "$FORMULA_FILE"
+    sed -i.bak "s|sha256 \".*\"|sha256 \"${sha256}\"|" "$FORMULA_FILE"
+    rm -f "${FORMULA_FILE}.bak"
+
+    local updated_sha
+    updated_sha=$(grep 'sha256 "' "$FORMULA_FILE" | grep -oE '[a-f0-9]{64}')
+
+    if [[ "$updated_sha" != "$sha256" ]]; then
+        log_error "SHA256 mismatch after update: expected $sha256, got $updated_sha"
+        restore_backup "$FORMULA_FILE"
+        return 1
+    fi
+
+    cleanup_backup "$FORMULA_FILE"
+    log_success "Formula updated to version $version"
+}
+
+main() {
+    local version="${1:?Usage: $0 VERSION SHA256}"
+    local sha256="${2:?SHA256 required}"
+
+    update_formula "$version" "$sha256"
+}
+
+main "$@"

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -euo pipefail
 
 source "$(dirname "$0")/utils.sh"
 
@@ -17,15 +16,14 @@ update_formula() {
 
     log_info "Updating Formula to version $version..."
 
-    sed -i.bak "s|url \"https://www.recoll.org/recoll-.*\.tar\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" "$FORMULA_FILE"
-    sed -i.bak "s|sha256 \".*\"|sha256 \"${sha256}\"|" "$FORMULA_FILE"
-    rm -f "${FORMULA_FILE}.bak"
+    sed -i '' -e "s|url \"https://www.recoll.org/recoll-.*\.tar\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" \
+              -e "s|sha256 \".*\"|sha256 \"${sha256}\"|" "$FORMULA_FILE"
 
-    local updated_sha
-    updated_sha=$(grep 'sha256 "' "$FORMULA_FILE" | grep -oE '[a-f0-9]{64}')
+    local updated_ver
+    updated_ver=$(extract_formula_version "$FORMULA_FILE")
 
-    if [[ "$updated_sha" != "$sha256" ]]; then
-        log_error "SHA256 mismatch after update: expected $sha256, got $updated_sha"
+    if [[ "$updated_ver" != "$version" ]]; then
+        log_error "Version mismatch after update: expected $version, got $updated_ver"
         restore_backup "$FORMULA_FILE"
         return 1
     fi

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -191,6 +191,23 @@ extract_latest_version() {
 }
 
 # =============================================================================
+# FORMULA UTILITIES
+# =============================================================================
+
+extract_formula_version() {
+    local formula_file="$1"
+
+    validate_file_exists "$formula_file" "Formula file" || return 1
+
+    local version
+    version=$(grep -E '^\s+url "' "$formula_file" | grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/recoll-//')
+
+    validate_not_empty "$version" "Formula version" || return 1
+
+    echo "$version"
+}
+
+# =============================================================================
 # EXIT HANDLING (Errors should never pass silently)
 # =============================================================================
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -200,7 +200,7 @@ extract_formula_version() {
     validate_file_exists "$formula_file" "Formula file" || return 1
 
     local version
-    version=$(grep -E '^\s+url "' "$formula_file" | grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/recoll-//')
+    version=$(grep -E '^[[:space:]]+url "' "$formula_file" | grep -oE 'recoll-[0-9]+\.[0-9]+\.[0-9]+' | sed 's/recoll-//')
 
     validate_not_empty "$version" "Formula version" || return 1
 


### PR DESCRIPTION
## Summary

- Add `Formula/recoll.rb` — full-featured Homebrew Formula building Recoll from source with Qt6 GUI, WebEngine preview, aspell, fsevents, recollq, and rclgrep
- Patch 3 upstream macOS build bugs (missing IOKit, rclgrep deps, finderxattr) via `inreplace`
- Add `scripts/check-formula-version.sh` and `scripts/update-formula.sh` for automated Formula updates
- Extend CI to test Formula (audit + build-from-source) and auto-update alongside Cask
- Update README with dual install options (Cask recommended, Formula for power users)

## Test plan

- [x] `brew style Formula/recoll.rb` — passes
- [x] `brew audit --online Formula/recoll.rb` — passes
- [x] `brew install --build-from-source recoll` — succeeds (~26s, 229 files, 12.2MB)
- [x] `brew test recoll` — passes
- [x] GUI (`recoll`), indexer (`recollindex`), CLI query (`recollq`), index-less search (`rclgrep`) all functional
- [x] Code review via `/simplify` — all issues resolved