### PR TITLE
fix: add missing semicolons to Perl one-liner in update-formula.sh

### DIFF
--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -21,8 +21,8 @@ update_formula() {
 
     log_info "Updating Formula to version $version..."
 
-    perl -pi -e "s|url \"https://www.recoll.org/recoll-.*\\.tar\\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" \
-             -e "s|^  sha256 \".*\"$|  sha256 \"${sha256}\"|" "$FORMULA_FILE"
+    perl -pi -e "s|url \"https://www.recoll.org/recoll-.*\\.tar\\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|;" \
+             -e "s|^  sha256 \".*\"$|  sha256 \"${sha256}\"|;" "$FORMULA_FILE"
 
     local updated_ver
     updated_ver=$(extract_formula_version "$FORMULA_FILE")


### PR DESCRIPTION
## Summary
- Fix syntax error in `scripts/update-formula.sh` where multiple Perl `-e` flags were missing statement-terminating semicolons
- This caused the "Update Recoll" GitHub Action to fail with `syntax error at -e line 2`

## Test plan
- [ ] Manually trigger the "Update Recoll" workflow after merge
- [ ] Verify the workflow completes successfully