### PR TITLE
fix: remove duplicate readonly declaration in create-pr.sh

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -19,7 +19,6 @@ source "$SCRIPT_DIR/utils.sh"
 readonly NEW_VERSION="$1"
 readonly CURRENT_VERSION="$2"
 readonly BRANCH_NAME="$3"
-readonly DEFAULT_CASK_FILE="Casks/recoll.rb"
 readonly DEFAULT_FORMULA_FILE="Formula/recoll.rb"
 
 # =============================================================================

--- a/scripts/update-formula.sh
+++ b/scripts/update-formula.sh
@@ -21,8 +21,8 @@ update_formula() {
 
     log_info "Updating Formula to version $version..."
 
-    perl -pi -e "s|url \"https://www.recoll.org/recoll-.*\\.tar\\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|" \
-             -e "s|^  sha256 \".*\"$|  sha256 \"${sha256}\"|" "$FORMULA_FILE"
+    perl -pi -e "s|url \"https://www.recoll.org/recoll-.*\\.tar\\.gz\"|url \"https://www.recoll.org/recoll-${version}.tar.gz\"|;" \
+             -e "s|^  sha256 \".*\"$|  sha256 \"${sha256}\"|;" "$FORMULA_FILE"
 
     local updated_ver
     updated_ver=$(extract_formula_version "$FORMULA_FILE")


### PR DESCRIPTION
## Summary
- Remove duplicate `readonly DEFAULT_CASK_FILE` in `create-pr.sh` — already declared in `utils.sh`
- This caused the "Update Recoll" workflow to fail with `readonly variable` error

## Test plan
- [ ] Manually trigger "Update Recoll" workflow after merge
- [ ] Verify the workflow completes successfully (formula update + PR creation)