### PR TITLE
fix: replace deprecated depends_on macos string format and clean cask style

### DIFF
--- a/Casks/recoll.rb
+++ b/Casks/recoll.rb
@@ -1,28 +1,27 @@
-cask 'recoll' do
-  version '1.43.6-20251014-af2d6350'
-  sha256 '92c00c2049808a6fa0447eb033f03885826d4b19411d13f02b6e0233939b91bd'
-  name 'Recoll'
-  desc 'Full-text search for your desktop.'
+cask "recoll" do
+  version "1.43.6-20251014-af2d6350"
+  sha256 "92c00c2049808a6fa0447eb033f03885826d4b19411d13f02b6e0233939b91bd"
 
-  homepage 'https://www.recoll.org/'
-
-  depends_on macos: '>= :big_sur'
-
-  app 'Recoll.app'
+  url "https://www.recoll.org/downloads/macos/recoll-#{version}.dmg"
+  name "Recoll"
+  desc "Full-text search for your desktop"
+  homepage "https://www.recoll.org/"
 
   livecheck do
-    url 'https://www.recoll.org/downloads/macos/'
+    url "https://www.recoll.org/downloads/macos/"
     regex(/href="recoll[._-]([\d.-]+[a-f0-9]+)\.dmg"/i)
   end
 
-  url "https://www.recoll.org/downloads/macos/recoll-#{version}.dmg"
+  depends_on macos: :big_sur
+
+  app "Recoll.app"
 
   postflight do
-    system_command 'xattr', args: ['-rd', 'com.apple.quarantine', "#{appdir}/Recoll.app"]
+    system_command "xattr", args: ["-rd", "com.apple.quarantine", "#{appdir}/Recoll.app"]
   end
 
   zap trash: [
-    '~/.recoll',
-    '~/.config/Recoll.org'
+    "~/.config/Recoll.org",
+    "~/.recoll",
   ]
 end


### PR DESCRIPTION
## Summary

- Replace the deprecated string comparison `depends_on macos: '>= :big_sur'` with the symbol form `depends_on macos: :big_sur`, silencing the Homebrew deprecation warning that fires on every `brew` invocation touching this tap.
- Run `brew style --fix` to clear all 29 outstanding offenses (quote style, stanza order, stanza grouping, `desc` trailing period, `zap` array ordering & trailing comma).

## Why

Homebrew is phasing out the string comparison format for `depends_on macos:`. It currently emits a deprecation warning and has already been observed to break operations like `brew untap` for some users (Homebrew/brew#22600). It also fails `brew audit`, which will block this tap's CI down the road.

Semantically, `:big_sur` is equivalent to `'>= :big_sur'` — the symbol form is already interpreted as a minimum-version requirement, so there is no behavior change for installers.

## Test plan

- [x] `brew style ./Casks/recoll.rb` → `no offenses detected`
- [x] Confirm no remaining deprecation warning is emitted on `brew` commands hitting this cask
- [ ] Reviewer: `brew install --cask ./Casks/recoll.rb` on macOS ≥ Big Sur